### PR TITLE
Throw Meteor errors instead of logging errors

### DIFF
--- a/server/modules/github/github.js
+++ b/server/modules/github/github.js
@@ -15,7 +15,7 @@ Meteor.publish('github', function(organization) {
       parseResult = function(callback) {
         return function(err, res) {
           if (err) {
-            console.log(err);
+            throw new Meteor.Error(500, err);
           }
           callback(err, res);
         };
@@ -57,6 +57,7 @@ Meteor.publish('github', function(organization) {
         }
       }, function(err, res) {
         if (err) {
+          throw new Meteor.Error(500, err);
           return;
         }
 


### PR DESCRIPTION
Pretty self-explanatory :) This throws a Meteor error instead of logging the errors in the console.
