### PR TITLE
Coding Standards 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 server/modules/deployment
+private/node_modules

--- a/private/.jscsrc
+++ b/private/.jscsrc
@@ -1,0 +1,13 @@
+{
+  "validateIndentation":2,
+  "disallowTrailingWhitespace": true,
+  "disallowTrailingComma": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowSpacesInsideObjectBrackets": true,
+  "disallowSpacesInsideArrayBrackets": true
+}

--- a/private/.jshintrc
+++ b/private/.jshintrc
@@ -1,0 +1,19 @@
+{
+  "browser": true,
+  "curly": true,
+  "eqeqeq": true,
+  "forin": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "strict": true,
+  "trailing": true,
+  "undef": true,
+  "unused": "vars",
+  "strict": false,
+  "predef": [
+    "Meteor",
+    "Mongo"
+  ]
+}

--- a/private/gulpfile.js
+++ b/private/gulpfile.js
@@ -1,0 +1,27 @@
+/**
+ * @file
+ * Portable Gulp tool that checks a Meteor installation for js syntax errors.
+ */
+/* globals require */
+
+var gulp = require('gulp'),
+    jshint = require('gulp-jshint'),
+    jscs = require('gulp-jscs');
+
+/**
+ * @task lint
+ *   Runs JSCS and JSLint on module, theme, and gulp files. Excludes all
+ *   minified JavaScript files.
+ */
+gulp.task('cs', function () {
+  return gulp.src([
+    '../**/*.js',
+    '!../.meteor/**/*.js',
+    '!../packages/**/*.js',
+    '!node_modules/**/*.js',
+    'gulpfile.js'
+  ])
+  .pipe(jshint())
+  .pipe(jshint.reporter('default'))
+  .pipe(jscs());
+});

--- a/private/package.json
+++ b/private/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "contrib.report",
+  "description": "A web application for displaying an organization's collective open source contributions through GitHub. http://contrib.report",
+  "version": "0.0.1",
+  "bugs": {
+    "url": "https://github.com/chasingmaxwell/contrib.report/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:chasingmaxwell/contrib.report.git"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "gulp": "~3.8.10",
+    "gulp-jscs": "^1.3.1",
+    "gulp-jshint": "^1.6.2"
+  }
+}


### PR DESCRIPTION
This PR brings a coding standards sniffer.

The sniffer lives in the `/private` directory, because the project root is the Meteor root, and Meteor will process the `gulpfile.js` file if it lives in any other directory. This seems non-optimal to me, and It'd be cool if there was a better solution. This is generally why I put the Meteor project root in a project root subdirectory, but I didn't want to submit a major organizational change.

Steps to test:
- Open a console, and change the current directory to that of the `/private` dir in the root of this project.
- Run `npm install`.
- Run `gulp cs`. No errors will be reported.
- Create an error-prone block of code in a js file.
- Run `gulp cs` in the `/private` dir again.
- Ensure that error-prone block of code is reported.
